### PR TITLE
feat: 벡터 유사도 검색 구현

### DIFF
--- a/src/main/java/com/techrag/tech_rag_assitant/domain/chunk/ChunkRepository.java
+++ b/src/main/java/com/techrag/tech_rag_assitant/domain/chunk/ChunkRepository.java
@@ -9,9 +9,12 @@ import java.util.List;
 public interface ChunkRepository extends JpaRepository<Chunk, Long> {
 
     @Query(value = """
-        SELECT c.* FROM chunks c
+        SELECT c.id, c.document_id, c.content, c.embedding, c.created_at,
+               c.embedding <=> cast(:embedding as vector) AS distance
+        FROM chunks c
+        WHERE c.embedding IS NOT NULL
         ORDER BY c.embedding <=> cast(:embedding as vector)
         LIMIT :limit
         """, nativeQuery = true)
-    List<Chunk> findSimilarChunks(@Param("embedding") String embedding, @Param("limit") int limit);
+    List<Object[]> findSimilarChunksRaw(@Param("embedding") String embedding, @Param("limit") int limit);
 }

--- a/src/main/java/com/techrag/tech_rag_assitant/search/SearchController.java
+++ b/src/main/java/com/techrag/tech_rag_assitant/search/SearchController.java
@@ -1,0 +1,24 @@
+package com.techrag.tech_rag_assitant.search;
+
+import com.techrag.tech_rag_assitant.search.dto.SearchRequest;
+import com.techrag.tech_rag_assitant.search.dto.SearchResult;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/search")
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final SearchService searchService;
+
+    @PostMapping
+    public ResponseEntity<List<SearchResult>> search(@Valid @RequestBody SearchRequest request) {
+        List<SearchResult> results = searchService.search(request);
+        return ResponseEntity.ok(results);
+    }
+}

--- a/src/main/java/com/techrag/tech_rag_assitant/search/SearchService.java
+++ b/src/main/java/com/techrag/tech_rag_assitant/search/SearchService.java
@@ -1,0 +1,64 @@
+package com.techrag.tech_rag_assitant.search;
+
+import com.techrag.tech_rag_assitant.domain.chunk.ChunkRepository;
+import com.techrag.tech_rag_assitant.domain.document.Document;
+import com.techrag.tech_rag_assitant.domain.document.DocumentRepository;
+import com.techrag.tech_rag_assitant.embedding.EmbeddingService;
+import com.techrag.tech_rag_assitant.search.dto.SearchRequest;
+import com.techrag.tech_rag_assitant.search.dto.SearchResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SearchService {
+
+    private final ChunkRepository chunkRepository;
+    private final DocumentRepository documentRepository;
+    private final EmbeddingService embeddingService;
+
+    public List<SearchResult> search(SearchRequest request) {
+        log.info("Searching for: {}", request.getQuery());
+
+        // 질문 임베딩 생성
+        List<Double> queryEmbedding = embeddingService.createEmbedding(request.getQuery());
+        String embeddingStr = embeddingService.embeddingToString(queryEmbedding);
+
+        // 유사도 검색
+        List<Object[]> rawResults = chunkRepository.findSimilarChunksRaw(
+                embeddingStr, request.getLimit());
+
+        // 3과 변환
+        List<SearchResult> results = new ArrayList<>();
+        for (Object[] row : rawResults) {
+            Long chunkId = ((Number) row[0]).longValue();
+            Long documentId = ((Number) row[1]).longValue();
+            String content = (String) row[2];
+            Double distance = ((Number) row[5]).doubleValue();
+
+            Document document = documentRepository.findById(documentId)
+                    .orElse(null);
+
+            SearchResult result = SearchResult.builder()
+                    .chunkId(chunkId)
+                    .content(content)
+                    .documentId(documentId)
+                    .documentTitle(document != null ? document.getTitle() : null)
+                    .documentUrl(document != null ? document.getUrl() : null)
+                    .distance(distance)
+                    .build();
+
+            results.add(result);
+        }
+
+        log.info("Found {} similar chunks", results.size());
+        return results;
+    }
+}

--- a/src/main/java/com/techrag/tech_rag_assitant/search/dto/SearchRequest.java
+++ b/src/main/java/com/techrag/tech_rag_assitant/search/dto/SearchRequest.java
@@ -1,0 +1,15 @@
+package com.techrag.tech_rag_assitant.search.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SearchRequest {
+
+    @NotBlank(message = "질문을 입력해주세요")
+    private String query;
+
+    private int limit = 5;
+}

--- a/src/main/java/com/techrag/tech_rag_assitant/search/dto/SearchResult.java
+++ b/src/main/java/com/techrag/tech_rag_assitant/search/dto/SearchResult.java
@@ -1,0 +1,16 @@
+package com.techrag.tech_rag_assitant.search.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SearchResult {
+
+    private Long chunkId;
+    private String content;
+    private Long documentId;
+    private String documentTitle;
+    private String documentUrl;
+    private Double distance;
+}

--- a/src/test/java/com/techrag/tech_rag_assitant/search/SearchServiceTest.java
+++ b/src/test/java/com/techrag/tech_rag_assitant/search/SearchServiceTest.java
@@ -1,0 +1,98 @@
+package com.techrag.tech_rag_assitant.search;
+
+import com.techrag.tech_rag_assitant.domain.chunk.ChunkRepository;
+import com.techrag.tech_rag_assitant.domain.document.Document;
+import com.techrag.tech_rag_assitant.domain.document.DocumentRepository;
+import com.techrag.tech_rag_assitant.embedding.EmbeddingService;
+import com.techrag.tech_rag_assitant.search.dto.SearchRequest;
+import com.techrag.tech_rag_assitant.search.dto.SearchResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SearchServiceTest {
+
+    @Mock
+    private ChunkRepository chunkRepository;
+
+    @Mock
+    private DocumentRepository documentRepository;
+
+    @Mock
+    private EmbeddingService embeddingService;
+
+    @InjectMocks
+    private SearchService searchService;
+
+    @Test
+    @DisplayName("질문으로 유사한 청크 검색")
+    void search_returnsSimilarChunks() {
+        // given
+        SearchRequest request = new SearchRequest();
+        ReflectionTestUtils.setField(request, "query", "Spring Boot 설정 방법");
+        ReflectionTestUtils.setField(request, "limit", 5);
+
+        List<Double> embedding = Arrays.asList(0.1, 0.2, 0.3);
+        when(embeddingService.createEmbedding(anyString())).thenReturn(embedding);
+        when(embeddingService.embeddingToString(embedding)).thenReturn("[0.1,0.2,0.3]");
+
+        // Mock raw 결과: id, document_id, content, embedding, created_at, distance
+        Object[] row = new Object[]{1L, 1L, "Spring Boot 설정 내용", "[0.1,0.2]", null, 0.15};
+        List<Object[]> rawResults = new ArrayList<>();
+        rawResults.add(row);
+        when(chunkRepository.findSimilarChunksRaw(anyString(), anyInt()))
+                .thenReturn(rawResults);
+
+        Document document = Document.builder()
+                .url("https://example.com")
+                .title("Spring 가이드")
+                .originalText("...")
+                .build();
+        ReflectionTestUtils.setField(document, "id", 1L);
+        when(documentRepository.findById(1L)).thenReturn(Optional.of(document));
+
+        // when
+        List<SearchResult> results = searchService.search(request);
+
+        // then
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getContent()).isEqualTo("Spring Boot 설정 내용");
+        assertThat(results.get(0).getDocumentTitle()).isEqualTo("Spring 가이드");
+        assertThat(results.get(0).getDistance()).isEqualTo(0.15);
+    }
+
+    @Test
+    @DisplayName("검색 결과가 없는 경우 빈 리스트 반환")
+    void search_noResults_returnsEmptyList() {
+        // given
+        SearchRequest request = new SearchRequest();
+        ReflectionTestUtils.setField(request, "query", "존재하지 않는 내용");
+        ReflectionTestUtils.setField(request, "limit", 5);
+
+        List<Double> embedding = Arrays.asList(0.1, 0.2, 0.3);
+        when(embeddingService.createEmbedding(anyString())).thenReturn(embedding);
+        when(embeddingService.embeddingToString(embedding)).thenReturn("[0.1,0.2,0.3]");
+        when(chunkRepository.findSimilarChunksRaw(anyString(), anyInt()))
+                .thenReturn(new ArrayList<>());
+
+        // when
+        List<SearchResult> results = searchService.search(request);
+
+        // then
+        assertThat(results).isEmpty();
+    }
+}


### PR DESCRIPTION
Closes #8

## 개요
사용자 질문을 임베딩하고 pgvector로 유사한 청크를 검색합니다.

## 변경 사항
- SearchRequest, SearchResult DTO 생성
- ChunkRepository에 벡터 유사도 검색 메서드 추가
- SearchService: 질문 임베딩 + 코사인 유사도 검색
- SearchController: POST /api/search 엔드포인트

## API 명세

### POST /api/search
**Request:**
```json
{
  "query": "Spring Boot 설정 방법",
  "limit": 5
}
```

**Response:**
```json
[
  {
    "chunkId": 1,
    "content": "Spring Boot 설정 내용...",
    "documentId": 1,
    "documentTitle": "Spring 가이드",
    "documentUrl": "https://example.com",
    "distance": 0.15
  }
]
```

## 테스트
- SearchServiceTest: 유사도 검색 로직 테스트